### PR TITLE
Change for loop to C-style syntax in base.zpp.sh

### DIFF
--- a/zpp/include/base.zpp.sh
+++ b/zpp/include/base.zpp.sh
@@ -46,7 +46,7 @@ function zpp_str_repeat() {
   if [ "${TO}" -lt "${FROM}" ]; then return; fi
   RES="${START}${STR//@N/${FROM}}"
   (( ++FROM ))
-  for N in $(seq $FROM $TO); do
+  for (( N=FROM; N<=TO; N++ )); do
     RES="${RES}${SEP}${STR//@N/${N}}"
   done
   echo "${RES}${END}"


### PR DESCRIPTION
Issue with MacOS:
`seq 2 1` gives 
```
2
1
```
But on Linux is nothing.

To fix this, use the C-style loop syntax instead. 